### PR TITLE
WIP: Adapt to centos

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,10 +29,9 @@
     mode: 0644
 
 - name: Airflow | Installing dependencies
-  apt:
-    pkg: "{{ airflow_required_libs }}"
+  package:
+    name: "{{ airflow_required_libs }}"
     state: present
-    update_cache: true
 
 # See https://airflow.apache.org/docs/apache-airflow/stable/installation.html#installation-tools
 - name: Airflow | Install pip "{{ airflow_pip_version }}" version


### PR DESCRIPTION
### Description of the Change

This PR will use the Generic OS package manager `package` instead of `apt`

### Benefits

Allow to run this role on Redhat/CentOS server

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
